### PR TITLE
feat: dev docker-compose with database only

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,15 @@
+services:
+  db:
+    image: postgres:16
+    container_name: postgres
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: mydb
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- Adds `docker-compose.dev.yaml` with only the Postgres service for local development
- Allows running the backend outside Docker while keeping the database containerized
- Usage: `docker compose -f docker-compose.dev.yaml up -d`

## Test plan
- [ ] Run `docker compose -f docker-compose.dev.yaml up -d` and verify Postgres starts on port 5432
- [ ] Confirm connection with `psql -h localhost -U user -d mydb`
- [ ] Verify the local backend connects to the database correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)