### PR TITLE
fix: replace Postgres with MongoDB in docker-compose files

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,15 +1,14 @@
 services:
   db:
-    image: postgres:16
-    container_name: postgres
+    image: mongo:7
+    container_name: mongodb
     environment:
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: mydb
+      MONGO_INITDB_ROOT_USERNAME: user
+      MONGO_INITDB_ROOT_PASSWORD: password
     ports:
-      - "5432:5432"
+      - "27017:27017"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - mongodata:/data/db
 
 volumes:
-  pgdata:
+  mongodata:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,16 +24,15 @@ services:
       - backend
 
   db:
-    image: postgres:16
-    container_name: postgres
+    image: mongo:7
+    container_name: mongodb
     environment:
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: mydb
+      MONGO_INITDB_ROOT_USERNAME: user
+      MONGO_INITDB_ROOT_PASSWORD: password
     ports:
-      - "5432:5432"
+      - "27017:27017"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - mongodata:/data/db
 
 volumes:
-  pgdata:
+  mongodata:


### PR DESCRIPTION
## Summary
- Replaces PostgreSQL with MongoDB 7 in both `docker-compose.yaml` and `docker-compose.dev.yaml`
- The project uses Mongoose/MongoDB but the compose files were incorrectly set up with Postgres

## Changes
- `image: postgres:16` → `image: mongo:7`
- Postgres env vars → `MONGO_INITDB_ROOT_USERNAME` / `MONGO_INITDB_ROOT_PASSWORD`
- Port `5432` → `27017`
- Volume `pgdata` → `mongodata`

## Test plan
- [ ] Run `docker compose -f docker-compose.dev.yaml up -d` and verify MongoDB starts on port 27017
- [ ] Confirm connection with `mongosh mongodb://user:password@localhost:27017`

🤖 Generated with [Claude Code](https://claude.com/claude-code)