### PR TITLE
chore: add .claude/napkin.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ compose.yaml
 emailInsert.json
 requests.rest
 .vercel
+
+# Claude Code napkin (per-user agent memory)
+.claude/napkin.md


### PR DESCRIPTION
## Summary
- Add `.claude/napkin.md` to `.gitignore` to prevent agent memory files from being versioned
- Napkin files are per-user Claude Code agent memory and should remain local

🤖 Generated with [Claude Code](https://claude.com/claude-code)