### PR TITLE
fix(search): ler paginação `page` do query string

### DIFF
--- a/src/controller/searchController/index.mjs
+++ b/src/controller/searchController/index.mjs
@@ -6,17 +6,17 @@ export const searchProfessionalsHighlightsWeek = async (req, res) => {
   /*
   #swagger.tags = ['Search']
   #swagger.summary = 'Pesquisa os profissionais destaques da semana'
-  #swagger.description = 'Retorna uma lista paginada de até 10 profissionais que são destaques da semana. A paginação é controlada pelo parâmetro `page` na rota.'
+  #swagger.description = 'Retorna uma lista paginada de até 10 profissionais que são destaques da semana. A paginação é controlada pelo query param `page`.'
 
   #swagger.parameters['page'] = {
-    in: 'path',
+    in: 'query',
     description: 'Número da página para paginação (cada página retorna até 10 profissionais)',
     required: false,
     type: 'integer',
     example: 1
   }
 
-  #swagger.responses[200] = { 
+  #swagger.responses[200] = {
     description: 'Profissionais encontrados com sucesso',
     schema: {
       professionals: [
@@ -47,7 +47,7 @@ export const searchProfessionalsHighlightsWeek = async (req, res) => {
 */
 
   try {
-    let page = parseInt(req.params.page, 10) || 1;
+    let page = parseInt(req.query.page, 10) || 1;
 
     if (Number.isNaN(page)) {
       return res.status(400).json({ error: "Página inválida" });
@@ -108,7 +108,7 @@ export const searchProfessionalBySpeciality = async (req, res) => {
   }
 
   #swagger.parameters['page'] = {
-    in: 'path',
+    in: 'query',
     description: 'Número da página para paginação (cada página retorna até 10 profissionais)',
     required: false,
     type: 'integer',
@@ -153,7 +153,7 @@ export const searchProfessionalBySpeciality = async (req, res) => {
   }
 
   try {
-    let page = parseInt(req.params.page, 10) || 1;
+    let page = parseInt(req.query.page, 10) || 1;
 
     if (Number.isNaN(page)) {
       return res.status(400).json({ error: "Página inválida" });
@@ -214,7 +214,7 @@ export const searchBar = async (req, res) => {
   }
 
   #swagger.parameters['page'] = {
-    in: 'path',
+    in: 'query',
     description: 'Número da página para paginação (cada página retorna até 10 profissionais)',
     required: false,
     type: 'integer',
@@ -256,7 +256,7 @@ export const searchBar = async (req, res) => {
   const limit = 10;
 
   try {
-    let page = parseInt(req.params.page, 10) || 1;
+    let page = parseInt(req.query.page, 10) || 1;
 
     if (!terms) {
       return res.status(400).json({ error: "Parâmetros são obrigatórios para realizar a busca" });

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -2094,13 +2094,13 @@
           "Search"
         ],
         "summary": "Pesquisa os profissionais destaques da semana",
-        "description": "Retorna uma lista paginada de até 10 profissionais que são destaques da semana. A paginação é controlada pelo parâmetro `page` na rota.",
+        "description": "Retorna uma lista paginada de até 10 profissionais que são destaques da semana. A paginação é controlada pelo query param `page`.",
         "parameters": [
           {
             "name": "page",
-            "in": "path",
+            "in": "query",
             "description": "Número da página para paginação (cada página retorna até 10 profissionais)",
-            "required": true,
+            "required": false,
             "example": 1,
             "schema": {
               "type": "integer"
@@ -2310,9 +2310,9 @@
           },
           {
             "name": "page",
-            "in": "path",
+            "in": "query",
             "description": "Número da página para paginação (cada página retorna até 10 profissionais)",
-            "required": true,
+            "required": false,
             "example": 1,
             "schema": {
               "type": "integer"
@@ -2540,9 +2540,9 @@
           },
           {
             "name": "page",
-            "in": "path",
+            "in": "query",
             "description": "Número da página para paginação (cada página retorna até 10 profissionais)",
-            "required": true,
+            "required": false,
             "example": 1,
             "schema": {
               "type": "integer"


### PR DESCRIPTION
## Problema

Os 3 controllers de busca (\`searchProfessionalsHighlightsWeek\`, \`searchProfessionalBySpeciality\`, \`searchBar\`) leem \`req.params.page\`, mas nenhuma das rotas que monta eles tem placeholder \`:page\`:

\`\`\`js
router.get(\"/search/highlightsWeek\", ...);
router.get(\"/search/professionalBySpeciality/:speciality\", ...);
router.get(\"/search/searchBar/:terms\", ...);
\`\`\`

Resultado: \`req.params.page\` é sempre \`undefined\` → controller cai no fallback \`|| 1\` → toda chamada retorna a primeira página, independente do que o cliente mandar.

A spec OpenAPI também declarava \`page\` como \`in: 'path'\`, o que é inconsistente com a rota real e fez o Kubb gerar um client no front que nunca enviava \`page\` na request. @MateusFelS pegou isso testando paginação do search no front (developmentHC/conectaBemFront#210, #209).

## Fix

Os 3 handlers passam a ler \`req.query.page\`. Anotações swagger atualizadas pra \`in: 'query'\`. \`swagger-output.json\` regenerado.

## Impacto no front

Tem 2 PRs no front com workaround pra esse bug (\`developmentHC/conectaBemFront#227\` e \`developmentHC/conectaBemFront#228\`) — eles injetam \`page\` manualmente no \`queryKey\` do React Query e mandam como axios \`params\`. Depois que esse PR mergeia e o Kubb for regenerado contra a spec corrigida, esses workarounds podem sair (vou abrir PR de cleanup no front depois).

## Test plan

- [ ] \`GET /search/highlightsWeek?page=2\` retorna registros 11-20
- [ ] \`GET /search/professionalBySpeciality/Acupuntura?page=2\` retorna 2ª página da especialidade
- [ ] \`GET /search/searchBar/joao?page=2\` retorna 2ª página da busca
- [ ] Sem \`?page\` continua retornando página 1 (compatível)
- [ ] \`vitest\`: 108 testes passam
- [ ] Swagger UI mostra \`page\` como query param nos 3 endpoints