### PR TITLE
feat(search): aceitar filtros como array em /search/professionals

### DIFF
--- a/src/controller/searchController/index.mjs
+++ b/src/controller/searchController/index.mjs
@@ -320,25 +320,31 @@ export const getProfessionals = async (req, res) => {
 
   #swagger.parameters['specialty'] = {
     in: 'query',
-    description: 'Especialidade do profissional',
+    description: 'Especialidade do profissional. Pode ser repetido para filtrar por múltiplas especialidades (ex: ?specialty=Reiki&specialty=Acupuntura). Match com OR dentro do filtro.',
     required: false,
-    type: 'string',
+    type: 'array',
+    collectionFormat: 'multi',
+    items: { type: 'string' },
     example: 'Reiki'
   }
 
   #swagger.parameters['service'] = {
     in: 'query',
-    description: 'Tipo de serviço oferecido',
+    description: 'Tipo de serviço oferecido. Pode ser repetido para múltiplos serviços (ex: ?service=Pet+Friendly&service=LGBTQIAP%2B+Friendly). Match com OR.',
     required: false,
-    type: 'string',
+    type: 'array',
+    collectionFormat: 'multi',
+    items: { type: 'string' },
     example: 'Pet Friendly'
   }
 
   #swagger.parameters['accessibility'] = {
     in: 'query',
-    description: 'Filtro de acessibilidade oferecida pelo profissional',
+    description: 'Filtro de acessibilidade oferecida pelo profissional. Pode ser repetido para múltiplos itens (ex: ?accessibility=Libras&accessibility=Rampas). Match com OR.',
     required: false,
-    type: 'string',
+    type: 'array',
+    collectionFormat: 'multi',
+    items: { type: 'string' },
     example: 'Libras'
   }
 
@@ -366,22 +372,31 @@ export const getProfessionals = async (req, res) => {
 
     const filters = { userType: { $in: ["professional"] } };
 
-    if (specialty) {
-      filters.professionalSpecialties = {
-        $in: [new RegExp(`^${escapeRegex(specialty)}$`, "i")],
-      };
+    // Normalize each filter to an array of regex matchers so the same code
+    // path handles `?specialty=A`, `?specialty=A&specialty=B` and absent.
+    const toRegexList = (value) => {
+      if (value === undefined || value === null) return null;
+      const list = Array.isArray(value) ? value : [value];
+      const cleaned = list
+        .map((item) => (typeof item === "string" ? item.trim() : ""))
+        .filter((item) => item.length > 0);
+      if (cleaned.length === 0) return null;
+      return cleaned.map((item) => new RegExp(`^${escapeRegex(item)}$`, "i"));
+    };
+
+    const specialtyRegexes = toRegexList(specialty);
+    if (specialtyRegexes) {
+      filters.professionalSpecialties = { $in: specialtyRegexes };
     }
 
-    if (service) {
-      filters.professionalServicePreferences = {
-        $in: [new RegExp(`^${escapeRegex(service)}$`, "i")],
-      };
+    const serviceRegexes = toRegexList(service);
+    if (serviceRegexes) {
+      filters.professionalServicePreferences = { $in: serviceRegexes };
     }
 
-    if (accessibility) {
-      filters.accessibility = {
-        $in: [new RegExp(`^${escapeRegex(accessibility)}$`, "i")],
-      };
+    const accessibilityRegexes = toRegexList(accessibility);
+    if (accessibilityRegexes) {
+      filters.accessibility = { $in: accessibilityRegexes };
     }
 
     const totalProfessionals = await User.countDocuments(filters);

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -2761,31 +2761,43 @@
           {
             "name": "specialty",
             "in": "query",
-            "description": "Especialidade do profissional",
+            "description": "Especialidade do profissional. Pode ser repetido para filtrar por múltiplas especialidades (ex: ?specialty=Reiki&specialty=Acupuntura). Match com OR dentro do filtro.",
             "required": false,
+            "collectionFormat": "multi",
+            "items": {
+              "type": "string"
+            },
             "example": "Reiki",
             "schema": {
-              "type": "string"
+              "type": "array"
             }
           },
           {
             "name": "service",
             "in": "query",
-            "description": "Tipo de serviço oferecido",
+            "description": "Tipo de serviço oferecido. Pode ser repetido para múltiplos serviços (ex: ?service=Pet+Friendly&service=LGBTQIAP%2B+Friendly). Match com OR.",
             "required": false,
+            "collectionFormat": "multi",
+            "items": {
+              "type": "string"
+            },
             "example": "Pet Friendly",
             "schema": {
-              "type": "string"
+              "type": "array"
             }
           },
           {
             "name": "accessibility",
             "in": "query",
-            "description": "Filtro de acessibilidade oferecida pelo profissional",
+            "description": "Filtro de acessibilidade oferecida pelo profissional. Pode ser repetido para múltiplos itens (ex: ?accessibility=Libras&accessibility=Rampas). Match com OR.",
             "required": false,
+            "collectionFormat": "multi",
+            "items": {
+              "type": "string"
+            },
             "example": "Libras",
             "schema": {
-              "type": "string"
+              "type": "array"
             }
           },
           {
@@ -2796,6 +2808,55 @@
             "example": 1,
             "schema": {
               "type": "integer"
+            }
+          },
+          {
+            "name": "in",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "required",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "collectionFormat",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "items",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "example",
+            "in": "query",
+            "schema": {
+              "type": "string"
             }
           }
         ],


### PR DESCRIPTION
## Problema

\`getProfessionals\` aceita \`specialty\`, \`service\` e \`accessibility\` como query param, mas tratava cada um como string única. Se o cliente mandasse o mesmo filtro 2x (Express transforma repeats em array), o \`new RegExp(escapeRegex(value))\` quebrava.

A UI de filtros do front permite selecionar várias especialidades/serviços/acessibilidades ao mesmo tempo. Hoje o front é obrigado a enviar só o primeiro item de cada array por causa dessa limitação (discussão em developmentHC/conectaBemFront#195).

## Fix

Normaliza cada filtro pra array de regex matchers antes de montar a query:

- Vazio / ausente: skip
- String única: continua funcionando (\`?specialty=Reiki\`)
- Repetidos: match com OR (\`?specialty=Reiki&specialty=Acupuntura\`) — exatamente o que o \`\$in\` do Mongo já faz

Anotações swagger atualizadas pra declarar cada filtro como \`type: 'array', collectionFormat: 'multi'\` pro Kubb gerar client que aceita array.

## Fora de escopo

Filtros \`availability\`, \`value\` e \`distance\` que a UI do front também coleta. Esses precisam:

- \`availability\`: campo novo no User schema com slots de horário
- \`value\`: campo novo de preço (range \$/\$\$/\$\$\$)
- \`distance\`: coordenadas geo (lat/lng) no \`addressSchema\` + index \`2dsphere\` + geo query

Trabalho maior, vai em PRs separados. Flag em developmentHC/conectaBemFront#195.

## Test plan

- [ ] \`GET /search/professionals?specialty=Reiki\` continua funcionando
- [ ] \`GET /search/professionals?specialty=Reiki&specialty=Acupuntura\` retorna profissionais de qualquer uma das 2 especialidades
- [ ] \`GET /search/professionals?service=Pet+Friendly&service=LGBTQIAP%2B+Friendly\` mesma lógica
- [ ] \`GET /search/professionals?specialty=Reiki&accessibility=Libras&accessibility=Rampas\` combina filtros (AND entre filtros, OR dentro de cada)
- [ ] Sem filtros: retorna todos profissionais (compatível)
- [ ] \`vitest\`: 108 testes passam