### PR TITLE
fix(swagger): emitir AddUserPatient/AddUserProfessional verbatim

### DIFF
--- a/src/swagger.mjs
+++ b/src/swagger.mjs
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import glob from "glob";
@@ -273,4 +274,30 @@ routes.forEach((routeGlob) => {
   } catch (_err) {}
 });
 
-swaggerAutogen(options)(outputFile, routes, doc);
+// swagger-autogen treats every value passed to `components.schemas` as a
+// "sample object" and re-runs its type-inference pass on it. When we hand
+// it a real OpenAPI schema (`{ type: "object", required: [...], properties: {...} }`),
+// the inference pass converts every property of the schema itself
+// (`type`, `required`, `properties`) into JSON Schema metadata, producing
+// nonsense like `properties.type.example = "object"`. The generated
+// frontend client (Kubb) then receives a useless type and the consumer
+// has to fall back to `any`.
+//
+// Workaround: after the autogen finishes, overwrite the affected schemas
+// in `swagger-output.json` with the literal definitions we wrote in `doc`.
+// Deep clone so the autogen pass does not mutate the original literal
+// schema definitions before we re-apply them.
+const RAW_SCHEMAS = JSON.parse(JSON.stringify(doc.components.schemas));
+const outputPath = path.resolve(__dirname, outputFile);
+
+await swaggerAutogen(options)(outputFile, routes, doc);
+
+if (fs.existsSync(outputPath)) {
+  const generated = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  generated.components = generated.components ?? {};
+  generated.components.schemas = {
+    ...generated.components.schemas,
+    ...RAW_SCHEMAS,
+  };
+  fs.writeFileSync(outputPath, `${JSON.stringify(generated, null, 2)}\n`);
+}

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -5553,1089 +5553,369 @@
     "schemas": {
       "AddUserPatient": {
         "type": "object",
+        "required": [
+          "userId",
+          "name",
+          "birthdayDate",
+          "residentialAddress",
+          "userSpecialties",
+          "userServicePreferences"
+        ],
         "properties": {
-          "type": {
+          "userId": {
             "type": "string",
-            "example": "object"
+            "example": "689dd16cfc1851d20da42b55"
           },
-          "required": {
-            "type": "array",
-            "example": [
-              "userId",
-              "name",
-              "birthdayDate",
-              "residentialAddress",
-              "userSpecialties",
-              "userServicePreferences"
-            ],
-            "items": {
-              "type": "string"
-            }
+          "name": {
+            "type": "string",
+            "example": "João Silva"
           },
-          "properties": {
+          "birthdayDate": {
+            "type": "number",
+            "example": 1632824400000
+          },
+          "residentialAddress": {
             "type": "object",
+            "required": [
+              "cep",
+              "endereco",
+              "bairro",
+              "numero",
+              "cidade",
+              "estado"
+            ],
             "properties": {
-              "userId": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "string"
-                  },
-                  "example": {
-                    "type": "string",
-                    "example": "689dd16cfc1851d20da42b55"
-                  }
-                }
+              "cep": {
+                "type": "string",
+                "example": "13295-000"
+              },
+              "endereco": {
+                "type": "string",
+                "example": "Rua das Orquídeas"
+              },
+              "bairro": {
+                "type": "string",
+                "example": "Centro"
+              },
+              "numero": {
+                "type": "string",
+                "example": "123"
+              },
+              "cidade": {
+                "type": "string",
+                "example": "Itupeva"
+              },
+              "estado": {
+                "type": "string",
+                "example": "SP"
+              },
+              "complemento": {
+                "type": "string",
+                "example": "Apto 101"
               },
               "name": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "string"
-                  },
-                  "example": {
-                    "type": "string",
-                    "example": "João Silva"
-                  }
-                }
+                "type": "string",
+                "example": "Minha casa"
               },
-              "birthdayDate": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "number"
-                  },
-                  "example": {
-                    "type": "number",
-                    "example": 1632824400000
-                  }
-                }
-              },
-              "residentialAddress": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "object"
-                  },
-                  "required": {
-                    "type": "array",
-                    "example": [
-                      "cep",
-                      "endereco",
-                      "bairro",
-                      "numero",
-                      "cidade",
-                      "estado"
-                    ],
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "properties": {
-                    "type": "object",
-                    "properties": {
-                      "cep": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "13295-000"
-                          }
-                        }
-                      },
-                      "endereco": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Rua das Orquídeas"
-                          }
-                        }
-                      },
-                      "bairro": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Centro"
-                          }
-                        }
-                      },
-                      "numero": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "123"
-                          }
-                        }
-                      },
-                      "cidade": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Itupeva"
-                          }
-                        }
-                      },
-                      "estado": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "SP"
-                          }
-                        }
-                      },
-                      "complemento": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Apto 101"
-                          }
-                        }
-                      },
-                      "name": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Minha casa"
-                          }
-                        }
-                      },
-                      "type": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "enum": {
-                            "type": "array",
-                            "example": [
-                              "Casa",
-                              "Trabalho",
-                              "Outros"
-                            ],
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Casa"
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "userSpecialties": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "array"
-                  },
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "example": "string"
-                      }
-                    }
-                  },
-                  "example": {
-                    "type": "array",
-                    "example": [
-                      "Cardiologia",
-                      "Clínica Geral"
-                    ],
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "userServicePreferences": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "array"
-                  },
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "example": "string"
-                      }
-                    }
-                  },
-                  "example": {
-                    "type": "array",
-                    "example": [
-                      "Consulta",
-                      "Exame"
-                    ],
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "accessibility": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "array"
-                  },
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "example": "string"
-                      }
-                    }
-                  },
-                  "example": {
-                    "type": "array",
-                    "example": [
-                      "Cadeira de rodas",
-                      "Deficiência visual"
-                    ],
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "description": {
-                    "type": "string",
-                    "example": "Preferências de acessibilidade do paciente (opcional)"
-                  }
-                }
-              },
-              "profilePhoto": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "string"
-                  },
-                  "example": {
-                    "type": "string",
-                    "example": "https://res.cloudinary.com/.../foto.png"
-                  },
-                  "description": {
-                    "type": "string",
-                    "example": "URL da foto enviada anteriormente no upload"
-                  }
-                }
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Casa",
+                  "Trabalho",
+                  "Outros"
+                ],
+                "example": "Casa"
               }
             }
+          },
+          "userSpecialties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "Cardiologia",
+              "Clínica Geral"
+            ]
+          },
+          "userServicePreferences": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "Consulta",
+              "Exame"
+            ]
+          },
+          "accessibility": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "Cadeira de rodas",
+              "Deficiência visual"
+            ],
+            "description": "Preferências de acessibilidade do paciente (opcional)"
+          },
+          "profilePhoto": {
+            "type": "string",
+            "example": "https://res.cloudinary.com/.../foto.png",
+            "description": "URL da foto enviada anteriormente no upload"
           }
-        },
-        "xml": {
-          "name": "AddUserPatient"
         }
       },
       "AddUserProfessional": {
         "type": "object",
+        "required": [
+          "userId",
+          "name",
+          "birthdayDate",
+          "CNPJCPFProfissional",
+          "residentialAddress",
+          "clinic",
+          "professionalSpecialties",
+          "professionalServicePreferences"
+        ],
         "properties": {
-          "type": {
+          "userId": {
             "type": "string",
-            "example": "object"
+            "example": "689dd16cfc1851d20da42b55"
           },
-          "required": {
-            "type": "array",
-            "example": [
-              "userId",
-              "name",
-              "birthdayDate",
-              "CNPJCPFProfissional",
-              "residentialAddress",
-              "clinic",
-              "professionalSpecialties",
-              "professionalServicePreferences"
-            ],
-            "items": {
-              "type": "string"
-            }
+          "name": {
+            "type": "string",
+            "example": "João Silva"
           },
-          "properties": {
+          "birthdayDate": {
+            "type": "number",
+            "example": 1632824400000
+          },
+          "CNPJCPFProfissional": {
+            "type": "string",
+            "example": "123.456.789-00"
+          },
+          "residentialAddress": {
             "type": "object",
+            "required": [
+              "cep",
+              "endereco",
+              "bairro",
+              "numero",
+              "cidade",
+              "estado"
+            ],
             "properties": {
-              "userId": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "string"
-                  },
-                  "example": {
-                    "type": "string",
-                    "example": "689dd16cfc1851d20da42b55"
-                  }
-                }
+              "cep": {
+                "type": "string",
+                "example": "12345-678"
+              },
+              "endereco": {
+                "type": "string",
+                "example": "Avenida Paulista"
+              },
+              "bairro": {
+                "type": "string",
+                "example": "Bela Vista"
+              },
+              "numero": {
+                "type": "string",
+                "example": "1000",
+                "description": "Opcional"
+              },
+              "cidade": {
+                "type": "string",
+                "example": "São Paulo"
+              },
+              "estado": {
+                "type": "string",
+                "example": "SP"
+              },
+              "complemento": {
+                "type": "string",
+                "example": "Sala 42"
               },
               "name": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "string"
-                  },
-                  "example": {
-                    "type": "string",
-                    "example": "João Silva"
-                  }
-                }
+                "type": "string",
+                "example": "Minha casa"
               },
-              "birthdayDate": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "number"
-                  },
-                  "example": {
-                    "type": "number",
-                    "example": 1632824400000
-                  }
-                }
-              },
-              "CNPJCPFProfissional": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "string"
-                  },
-                  "example": {
-                    "type": "string",
-                    "example": "123.456.789-00"
-                  }
-                }
-              },
-              "residentialAddress": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "object"
-                  },
-                  "required": {
-                    "type": "array",
-                    "example": [
-                      "cep",
-                      "endereco",
-                      "bairro",
-                      "numero",
-                      "cidade",
-                      "estado"
-                    ],
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "properties": {
-                    "type": "object",
-                    "properties": {
-                      "cep": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "12345-678"
-                          }
-                        }
-                      },
-                      "endereco": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Avenida Paulista"
-                          }
-                        }
-                      },
-                      "bairro": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Bela Vista"
-                          }
-                        }
-                      },
-                      "numero": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "1000"
-                          },
-                          "description": {
-                            "type": "string",
-                            "example": "Opcional"
-                          }
-                        }
-                      },
-                      "cidade": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "São Paulo"
-                          }
-                        }
-                      },
-                      "estado": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "SP"
-                          }
-                        }
-                      },
-                      "complemento": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Sala 42"
-                          }
-                        }
-                      },
-                      "name": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Minha casa"
-                          }
-                        }
-                      },
-                      "type": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "enum": {
-                            "type": "array",
-                            "example": [
-                              "Casa",
-                              "Trabalho",
-                              "Outros"
-                            ],
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Casa"
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "clinic": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "object"
-                  },
-                  "required": {
-                    "type": "array",
-                    "example": [
-                      "name",
-                      "cep",
-                      "address",
-                      "neighborhood",
-                      "number",
-                      "city",
-                      "state"
-                    ],
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "properties": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Clínica Saúde Total"
-                          }
-                        }
-                      },
-                      "cep": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "12345-678"
-                          }
-                        }
-                      },
-                      "address": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Avenida Paulista"
-                          }
-                        }
-                      },
-                      "neighborhood": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Bela Vista"
-                          }
-                        }
-                      },
-                      "number": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "1000"
-                          }
-                        }
-                      },
-                      "city": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "São Paulo"
-                          }
-                        }
-                      },
-                      "state": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "SP"
-                          }
-                        }
-                      },
-                      "addition": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Sala 123"
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "professionalSpecialties": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "array"
-                  },
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "example": "string"
-                      }
-                    }
-                  },
-                  "example": {
-                    "type": "array",
-                    "example": [
-                      "Cardiologia",
-                      "Clínica Geral"
-                    ],
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "professionalServicePreferences": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "array"
-                  },
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "example": "string"
-                      }
-                    }
-                  },
-                  "example": {
-                    "type": "array",
-                    "example": [
-                      "Consulta",
-                      "Exame"
-                    ],
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "otherProfessionalSpecialties": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "array"
-                  },
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "example": "string"
-                      }
-                    }
-                  },
-                  "example": {
-                    "type": "array",
-                    "example": [
-                      "Acupuntura"
-                    ],
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "description": {
-                    "type": "string",
-                    "example": "Opcional"
-                  }
-                }
-              },
-              "accessibility": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "array"
-                  },
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "example": "string"
-                      }
-                    }
-                  },
-                  "example": {
-                    "type": "array",
-                    "example": [
-                      "Rampa de acesso",
-                      "Banheiro adaptado"
-                    ],
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "description": {
-                    "type": "string",
-                    "example": "Preferências de acessibilidade do profissional (opcional)"
-                  }
-                }
-              },
-              "profilePhoto": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "string"
-                  },
-                  "example": {
-                    "type": "string",
-                    "example": "https://res.cloudinary.com/.../foto.png"
-                  },
-                  "description": {
-                    "type": "string",
-                    "example": "URL da foto enviada anteriormente no upload"
-                  }
-                }
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Casa",
+                  "Trabalho",
+                  "Outros"
+                ],
+                "example": "Casa"
               }
             }
+          },
+          "clinic": {
+            "type": "object",
+            "required": [
+              "name",
+              "cep",
+              "address",
+              "neighborhood",
+              "number",
+              "city",
+              "state"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "example": "Clínica Saúde Total"
+              },
+              "cep": {
+                "type": "string",
+                "example": "12345-678"
+              },
+              "address": {
+                "type": "string",
+                "example": "Avenida Paulista"
+              },
+              "neighborhood": {
+                "type": "string",
+                "example": "Bela Vista"
+              },
+              "number": {
+                "type": "string",
+                "example": "1000"
+              },
+              "city": {
+                "type": "string",
+                "example": "São Paulo"
+              },
+              "state": {
+                "type": "string",
+                "example": "SP"
+              },
+              "addition": {
+                "type": "string",
+                "example": "Sala 123"
+              }
+            }
+          },
+          "professionalSpecialties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "Cardiologia",
+              "Clínica Geral"
+            ]
+          },
+          "professionalServicePreferences": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "Consulta",
+              "Exame"
+            ]
+          },
+          "otherProfessionalSpecialties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "Acupuntura"
+            ],
+            "description": "Opcional"
+          },
+          "accessibility": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "Rampa de acesso",
+              "Banheiro adaptado"
+            ],
+            "description": "Preferências de acessibilidade do profissional (opcional)"
+          },
+          "profilePhoto": {
+            "type": "string",
+            "example": "https://res.cloudinary.com/.../foto.png",
+            "description": "URL da foto enviada anteriormente no upload"
           }
-        },
-        "xml": {
-          "name": "AddUserProfessional"
         }
       },
       "Appointment": {
         "type": "object",
         "properties": {
-          "type": {
+          "_id": {
             "type": "string",
-            "example": "object"
+            "example": "64fae32bd00141c1a2eaa321"
           },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "_id": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "string"
-                  },
-                  "example": {
-                    "type": "string",
-                    "example": "64fae32bd00141c1a2eaa321"
-                  }
-                }
-              },
-              "patient": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "string"
-                  },
-                  "example": {
-                    "type": "string",
-                    "example": "64fae24ad00141c1a2eaa320"
-                  }
-                }
-              },
-              "professional": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "string"
-                  },
-                  "example": {
-                    "type": "string",
-                    "example": "64fae109d00141c1a2eaa31f"
-                  }
-                }
-              },
-              "dateTime": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "string"
-                  },
-                  "format": {
-                    "type": "string",
-                    "example": "date-time"
-                  },
-                  "example": {
-                    "type": "string",
-                    "example": "2025-08-01T14:00:00.000Z"
-                  }
-                }
-              },
-              "status": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "string"
-                  },
-                  "example": {
-                    "type": "string",
-                    "example": "confirmed"
-                  }
-                }
-              }
-            }
+          "patient": {
+            "type": "string",
+            "example": "64fae24ad00141c1a2eaa320"
+          },
+          "professional": {
+            "type": "string",
+            "example": "64fae109d00141c1a2eaa31f"
+          },
+          "dateTime": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-08-01T14:00:00.000Z"
+          },
+          "status": {
+            "type": "string",
+            "example": "confirmed"
           }
-        },
-        "xml": {
-          "name": "Appointment"
         }
       },
       "WebhookMessageCreated": {
         "type": "object",
         "properties": {
+          "eventId": {
+            "type": "string",
+            "example": "e5ae2396-ff2c-4a6b-8906-73a4459d42cc"
+          },
           "type": {
             "type": "string",
-            "example": "object"
+            "example": "message.created"
           },
-          "properties": {
+          "occurredAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2025-08-05T22:48:13.781Z"
+          },
+          "data": {
             "type": "object",
             "properties": {
-              "eventId": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "string"
-                  },
-                  "example": {
-                    "type": "string",
-                    "example": "e5ae2396-ff2c-4a6b-8906-73a4459d42cc"
-                  }
-                }
+              "messageId": {
+                "type": "string",
+                "example": "68928a2d6acdb8a8dd58cc63"
               },
-              "type": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "string"
-                  },
-                  "example": {
-                    "type": "string",
-                    "example": "message.created"
-                  }
-                }
+              "conversation": {
+                "type": "string",
+                "example": "conv_teste_123"
               },
-              "occurredAt": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "string"
-                  },
-                  "format": {
-                    "type": "string",
-                    "example": "date-time"
-                  },
-                  "example": {
-                    "type": "string",
-                    "example": "2025-08-05T22:48:13.781Z"
-                  }
-                }
+              "sender": {
+                "type": "string",
+                "example": "68928a2d6acdb8a8dd58cc62"
               },
-              "data": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "object"
-                  },
-                  "properties": {
-                    "type": "object",
-                    "properties": {
-                      "messageId": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "68928a2d6acdb8a8dd58cc63"
-                          }
-                        }
-                      },
-                      "conversation": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "conv_teste_123"
-                          }
-                        }
-                      },
-                      "sender": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "68928a2d6acdb8a8dd58cc62"
-                          }
-                        }
-                      },
-                      "senderName": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Testador"
-                          }
-                        }
-                      },
-                      "content": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "Mensagem teste webhook"
-                          }
-                        }
-                      },
-                      "createdAt": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string",
-                            "example": "string"
-                          },
-                          "format": {
-                            "type": "string",
-                            "example": "date-time"
-                          },
-                          "example": {
-                            "type": "string",
-                            "example": "2025-08-05T22:48:13.592Z"
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
+              "senderName": {
+                "type": "string",
+                "example": "Testador"
+              },
+              "content": {
+                "type": "string",
+                "example": "Mensagem teste webhook"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time",
+                "example": "2025-08-05T22:48:13.592Z"
               }
             }
           }
-        },
-        "xml": {
-          "name": "WebhookMessageCreated"
         }
       }
     }


### PR DESCRIPTION
## Problema

\`swagger-autogen\` trata todo valor passado em \`components.schemas\` como **sample object** e reaplica a pass de inferência de tipos. Quando entregamos um OpenAPI schema real:

\`\`\`js
AddUserPatient: { type: \"object\", required: [...], properties: {...} }
\`\`\`

a inferência converte cada property da própria schema definition (\`type\`, \`required\`, \`properties\`) em JSON Schema metadata, produzindo lixo do tipo:

\`\`\`json
\"AddUserPatient\": {
  \"type\": \"object\",
  \"properties\": {
    \"type\": { \"type\": \"string\", \"example\": \"object\" },
    \"required\": { \"type\": \"array\", \"items\": { \"type\": \"string\" }, ... },
    \"properties\": {
      \"type\": \"object\",
      \"properties\": {
        \"userId\": {
          \"type\": \"object\",
          \"properties\": {
            \"type\": { \"type\": \"string\", \"example\": \"string\" },
            \"example\": { \"type\": \"string\", \"example\": \"...\" }
          }
        },
        ...
\`\`\`

Resultado: o Kubb no front gera um tipo inútil e o consumer (\`useRegisterPatient\`) cai num \`postAuthCreatepatient(data as any, ...)\`. O TODO já tava no código (developmentHC/conectaBemFront \`useRegisterPatient.ts\`):

> // TODO: remover \`as any\` quando o swagger gerar schemas corretos (hoje AddUserPatient vem como JSON Schema metadata em vez do payload real)

## Fix

Pós-processamento no \`src/swagger.mjs\`:

1. Faz deep clone de \`doc.components.schemas\` antes de passar pro autogen, pra autogen não mutar o original
2. Após o autogen rodar e gerar \`swagger-output.json\`, abre o JSON, sobrescreve \`components.schemas\` com os schemas literais e regrava

Diff esperado no \`swagger-output.json\`: schemas \`AddUserPatient\` e \`AddUserProfessional\` agora têm o shape real (\`type: \"object\"\`, \`required: [...]\`, \`properties: { userId: {type: \"string\", ...}, ... }\`).

## Impacto no front

Depois desse PR mergear e o Kubb ser regenerado, o \`as any\` em \`src/features/auth/hooks/useRegisterPatient.ts\` pode ser removido. Vou abrir PR de cleanup no front depois.

## Test plan

- [ ] \`npm run swagger\`: \`swagger-output.json\` mostra \`components.schemas.AddUserPatient.properties\` com \`userId\`, \`name\`, \`birthdayDate\`, \`residentialAddress\`, \`userSpecialties\`, \`userServicePreferences\`, \`accessibility\`, \`profilePhoto\` (não os campos sintéticos \`type\`/\`required\`/\`properties\`)
- [ ] Mesmo pra \`AddUserProfessional\`
- [ ] Swagger UI renderiza o schema certo na rota \`POST /auth/createPatient\` e \`POST /auth/createProfessional\`
- [ ] \`vitest\`: 108 testes passam