### PR TITLE
fix(cors): desabilitar ETag pra evitar CORS quebrado em 304

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -13,6 +13,15 @@ const __dirname = path.dirname(__filename);
 
 const app = express();
 
+// Express's default ETag handling responds with `304 Not Modified` on
+// matching `If-None-Match` and skips the rest of the middleware chain —
+// which means the `cors` middleware never gets to set
+// `Access-Control-Allow-Origin` on the 304 response. Browsers then block
+// the response as a CORS failure even though the cached body would have
+// been used. The cheapest fix that doesn't break correctness on a small
+// JSON API is to drop ETag generation entirely.
+app.disable("etag");
+
 app.use(cors(corsOptions));
 app.options("*", cors(corsOptions));
 app.use(cookieParser());


### PR DESCRIPTION
## Bug

Detectado testando o front em produção. \`/search\` no front quebrou com:

\`\`\`
Access to XMLHttpRequest at 'https://conecta-bem-back.vercel.app/search/professionals?page=1' from origin 'https://conecta-bem-front.vercel.app' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
\`\`\`

\`curl\` direto pro endpoint mostrava o backend saudável e CORS configurado certinho. O que diferenciava: o browser mandava \`If-None-Match: W/\"...\"\` (etag da response anterior cacheada).

Confirmado:

\`\`\`
$ curl -sI -H 'Origin: https://conecta-bem-front.vercel.app' \\
    -H 'If-None-Match: W/\"2145-CpS0/4slvS9l9gkt6la4n0oWQj0\"' \\
    'https://conecta-bem-back.vercel.app/search/professionals?page=1'

HTTP/2 304
cache-control: public, max-age=0, must-revalidate
date: ...
etag: W/\"2145-CpS0/4slvS9l9gkt6la4n0oWQj0\"
server: Vercel
vary: Origin
# ❌ sem access-control-allow-origin
\`\`\`

## Causa raiz

O Express, quando vê \`If-None-Match\` batendo com a ETag auto-gerada, dispara \`304 Not Modified\` antes do middleware \`cors\` reaplicar headers. A 304 sai sem \`Access-Control-Allow-Origin\` → o browser bloqueia mesmo o body cacheado sendo válido. Bug clássico Express + cors + ETag.

## Fix

\`app.disable('etag')\` no \`src/index.mjs\`. A API serve JSON pequeno, então perder o round-trip de GET condicional é desprezível comparado ao custo de debug de CORS-em-304.

## Test plan

- [ ] \`curl -sI -H 'Origin: https://conecta-bem-front.vercel.app' -H 'If-None-Match: W/\"qualquer-coisa\"' https://conecta-bem-back.vercel.app/search/professionals?page=1\` retorna 200 com \`access-control-allow-origin\` (não mais 304 sem header)
- [ ] Front recarrega \`/search\` sem CORS error
- [ ] Tests vitest 108/108 passam

Refs developmentHC/conectaBemFront#195