### PR TITLE
feat(specialties): adicionar paginação e filtro featured em GET /specialties

### DIFF
--- a/src/controller/specialtyController/index.mjs
+++ b/src/controller/specialtyController/index.mjs
@@ -1,56 +1,64 @@
 export const SPECIALTIES = [
-  { id: "acupuntura", name: "Acupuntura" },
-  { id: "aromaterapia", name: "Aromaterapia" },
-  { id: "arteterapia", name: "Arteterapia" },
-  { id: "biodanca", name: "Biodança" },
-  { id: "cardiologia", name: "Cardiologia" },
-  { id: "cromoterapia", name: "Cromoterapia" },
-  { id: "dermatologia", name: "Dermatologia" },
-  { id: "fisioterapia", name: "Fisioterapia" },
-  { id: "fitoterapia", name: "Fitoterapia" },
-  { id: "hipnoterapia", name: "Hipnoterapia" },
-  { id: "homeopatia", name: "Homeopatia" },
-  { id: "massoterapia", name: "Massoterapia" },
-  { id: "meditacao", name: "Meditação" },
-  { id: "musicoterapia", name: "Musicoterapia" },
-  { id: "osteopatia", name: "Osteopatia" },
-  { id: "pilates", name: "Pilates" },
-  { id: "quiropraxia", name: "Quiropraxia" },
-  { id: "reflexoterapia", name: "Reflexoterapia" },
-  { id: "reiki", name: "Reiki" },
-  { id: "yoga", name: "Yoga" },
+  { id: "acupuntura", name: "Acupuntura", featured: true },
+  { id: "aromaterapia", name: "Aromaterapia", featured: true },
+  { id: "arteterapia", name: "Arteterapia", featured: false },
+  { id: "biodanca", name: "Biodança", featured: false },
+  { id: "cardiologia", name: "Cardiologia", featured: false },
+  { id: "cromoterapia", name: "Cromoterapia", featured: false },
+  { id: "dermatologia", name: "Dermatologia", featured: false },
+  { id: "fisioterapia", name: "Fisioterapia", featured: false },
+  { id: "fitoterapia", name: "Fitoterapia", featured: false },
+  { id: "hipnoterapia", name: "Hipnoterapia", featured: false },
+  { id: "homeopatia", name: "Homeopatia", featured: false },
+  { id: "massoterapia", name: "Massoterapia", featured: false },
+  { id: "meditacao", name: "Meditação", featured: true },
+  { id: "musicoterapia", name: "Musicoterapia", featured: false },
+  { id: "osteopatia", name: "Osteopatia", featured: false },
+  { id: "pilates", name: "Pilates", featured: false },
+  { id: "quiropraxia", name: "Quiropraxia", featured: false },
+  { id: "reflexoterapia", name: "Reflexoterapia", featured: false },
+  { id: "reiki", name: "Reiki", featured: true },
+  { id: "yoga", name: "Yoga", featured: true },
 ];
 
-export const getSpecialties = (_req, res) => {
+export const getSpecialties = (req, res) => {
   /*
   #swagger.tags = ['Specialties']
-  #swagger.summary = 'Lista todas as especialidades'
-  #swagger.description = 'Retorna a lista canônica de especialidades disponíveis no sistema. Essa lista é utilizada como fonte única (single source of truth) para cadastro e filtros.'
+  #swagger.summary = 'Lista especialidades (paginada, com filtro de destaque)'
+  #swagger.description = 'Retorna a lista canônica de especialidades disponíveis no sistema. Essa lista é utilizada como fonte única (single source of truth) para cadastro e filtros. A paginação é controlada pelo query param `page` (cada página retorna até 10 itens). Use `featured=true` para restringir aos destaques exibidos na Home.'
+
+  #swagger.parameters['page'] = {
+    in: 'query',
+    description: 'Número da página para paginação (cada página retorna até 10 especialidades)',
+    required: false,
+    type: 'integer',
+    example: 1
+  }
+
+  #swagger.parameters['featured'] = {
+    in: 'query',
+    description: 'Quando true, retorna apenas as especialidades marcadas como destaque',
+    required: false,
+    type: 'boolean',
+    example: false
+  }
 
   #swagger.responses[200] = {
     description: 'Lista de especialidades retornada com sucesso',
-    schema: [
-        { id: "acupuntura", name: "Acupuntura" },
-        { id: "aromaterapia", name: "Aromaterapia" },
-        { id: "arteterapia", name: "Arteterapia" },
-        { id: "biodanca", name: "Biodança" },
-        { id: "cardiologia", name: "Cardiologia" },
-        { id: "cromoterapia", name: "Cromoterapia" },
-        { id: "dermatologia", name: "Dermatologia" },
-        { id: "fisioterapia", name: "Fisioterapia" },
-        { id: "fitoterapia", name: "Fitoterapia" },
-        { id: "hipnoterapia", name: "Hipnoterapia" },
-        { id: "homeopatia", name: "Homeopatia" },
-        { id: "massoterapia", name: "Massoterapia" },
-        { id: "meditacao", name: "Meditação" },
-        { id: "musicoterapia", name: "Musicoterapia" },
-        { id: "osteopatia", name: "Osteopatia" },
-        { id: "pilates", name: "Pilates" },
-        { id: "quiropraxia", name: "Quiropraxia" },
-        { id: "reflexoterapia", name: "Reflexoterapia" },
-        { id: "reiki", name: "Reiki" },
-        { id: "yoga", name: "Yoga" }
-    ]
+    schema: {
+      specialties: [
+        { id: "acupuntura", name: "Acupuntura", featured: true },
+        { id: "reiki", name: "Reiki", featured: true },
+        { id: "yoga", name: "Yoga", featured: true }
+      ],
+      page: 1,
+      pageCount: 1
+    }
+  }
+
+  #swagger.responses[400] = {
+    description: 'Página inválida',
+    schema: { error: "Página inválida" }
   }
 
   #swagger.responses[500] = {
@@ -60,5 +68,30 @@ export const getSpecialties = (_req, res) => {
   */
   res.set("Cache-Control", "public, max-age=86400");
 
-  return res.status(200).json(SPECIALTIES);
+  let page = parseInt(req.query.page, 10) || 1;
+
+  if (Number.isNaN(page) || page < 1) {
+    return res.status(400).json({ error: "Página inválida" });
+  }
+
+  const limit = 10;
+  const featuredOnly = req.query.featured === "true";
+
+  const source = featuredOnly ? SPECIALTIES.filter((s) => s.featured) : SPECIALTIES;
+
+  const total = source.length;
+  const pageCount = Math.max(1, Math.ceil(total / limit));
+
+  if (page > pageCount) {
+    page = pageCount;
+  }
+
+  const start = (page - 1) * limit;
+  const specialties = source.slice(start, start + limit);
+
+  return res.status(200).json({
+    specialties,
+    page,
+    pageCount,
+  });
 };

--- a/src/tests/controller/specialtyController.test.mjs
+++ b/src/tests/controller/specialtyController.test.mjs
@@ -1,29 +1,88 @@
 import { describe, expect, it, vi } from "vitest";
-import { getSpecialties } from "../../controller/specialtyController";
+import { getSpecialties, SPECIALTIES } from "../../controller/specialtyController";
+
+const makeRes = () => ({
+  status: vi.fn().mockReturnThis(),
+  json: vi.fn(),
+  set: vi.fn(),
+});
 
 describe("GET /specialties", () => {
-  it("should return 200 and specialties list", () => {
-    const req = {};
-
-    const res = {
-      status: vi.fn().mockReturnThis(),
-      json: vi.fn(),
-      set: vi.fn(),
-    };
+  it("returns 200 with paginated payload and full list on first page", () => {
+    const req = { query: {} };
+    const res = makeRes();
 
     getSpecialties(req, res);
 
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalled();
-
     const data = res.json.mock.calls[0][0];
 
-    expect(Array.isArray(data)).toBe(true);
-    expect(data.length).toBe(20);
+    expect(data).toHaveProperty("specialties");
+    expect(data).toHaveProperty("page", 1);
+    expect(data).toHaveProperty("pageCount", Math.ceil(SPECIALTIES.length / 10));
+    expect(Array.isArray(data.specialties)).toBe(true);
+    expect(data.specialties.length).toBe(10);
 
-    data.forEach((item) => {
+    data.specialties.forEach((item) => {
       expect(item).toHaveProperty("id");
       expect(item).toHaveProperty("name");
+      expect(item).toHaveProperty("featured");
     });
+  });
+
+  it("returns the remaining items on page 2", () => {
+    const req = { query: { page: "2" } };
+    const res = makeRes();
+
+    getSpecialties(req, res);
+
+    const data = res.json.mock.calls[0][0];
+    expect(data.page).toBe(2);
+    expect(data.specialties.length).toBe(SPECIALTIES.length - 10);
+  });
+
+  it("clamps page > pageCount to the last page", () => {
+    const req = { query: { page: "999" } };
+    const res = makeRes();
+
+    getSpecialties(req, res);
+
+    const data = res.json.mock.calls[0][0];
+    expect(data.page).toBe(data.pageCount);
+  });
+
+  it("returns 400 when page is not a positive integer", () => {
+    const req = { query: { page: "-1" } };
+    const res = makeRes();
+
+    getSpecialties(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: "Página inválida" });
+  });
+
+  it("returns only featured specialties when featured=true", () => {
+    const req = { query: { featured: "true" } };
+    const res = makeRes();
+
+    getSpecialties(req, res);
+
+    const data = res.json.mock.calls[0][0];
+    const expectedFeatured = SPECIALTIES.filter((s) => s.featured);
+
+    expect(data.specialties.length).toBe(expectedFeatured.length);
+    data.specialties.forEach((item) => {
+      expect(item.featured).toBe(true);
+    });
+  });
+
+  it("ignores featured filter when value is not 'true'", () => {
+    const req = { query: { featured: "1" } };
+    const res = makeRes();
+
+    getSpecialties(req, res);
+
+    const data = res.json.mock.calls[0][0];
+    expect(data.pageCount).toBe(Math.ceil(SPECIALTIES.length / 10));
   });
 });

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -3112,26 +3112,65 @@
         "tags": [
           "Specialties"
         ],
-        "summary": "Lista todas as especialidades",
-        "description": "Retorna a lista canônica de especialidades disponíveis no sistema. Essa lista é utilizada como fonte única (single source of truth) para cadastro e filtros.",
+        "summary": "Lista especialidades (paginada, com filtro de destaque)",
+        "description": "Retorna a lista canônica de especialidades disponíveis no sistema. Essa lista é utilizada como fonte única (single source of truth) para cadastro e filtros. A paginação é controlada pelo query param `page` (cada página retorna até 10 itens). Use `featured=true` para restringir aos destaques exibidos na Home.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Número da página para paginação (cada página retorna até 10 especialidades)",
+            "required": false,
+            "example": 1,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "featured",
+            "in": "query",
+            "description": "Quando true, retorna apenas as especialidades marcadas como destaque",
+            "required": false,
+            "example": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Lista de especialidades retornada com sucesso",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "example": "yoga"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "Yoga"
+                  "type": "object",
+                  "properties": {
+                    "specialties": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "example": "yoga"
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Yoga"
+                          },
+                          "featured": {
+                            "type": "boolean",
+                            "example": true
+                          }
+                        }
                       }
+                    },
+                    "page": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "pageCount": {
+                      "type": "number",
+                      "example": 1
                     }
                   },
                   "xml": {
@@ -3141,18 +3180,68 @@
               },
               "application/xml": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "example": "yoga"
-                      },
-                      "name": {
-                        "type": "string",
-                        "example": "Yoga"
+                  "type": "object",
+                  "properties": {
+                    "specialties": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "example": "yoga"
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Yoga"
+                          },
+                          "featured": {
+                            "type": "boolean",
+                            "example": true
+                          }
+                        }
                       }
+                    },
+                    "page": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "pageCount": {
+                      "type": "number",
+                      "example": 1
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Página inválida",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Página inválida"
+                    }
+                  },
+                  "xml": {
+                    "name": "main"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Página inválida"
                     }
                   },
                   "xml": {


### PR DESCRIPTION
## Contexto

A Home do front (`ProfessionalSection`) renderiza uma seção por especialidade — uma chamada `GET /search/professionalBySpeciality/:speciality` por seção. O `GET /specialties` atual devolve as 20 especialidades de uma vez, então quando a Poly trocou o fallback hardcoded por esse endpoint, a Home virou 20 seções + 20 requests. Conversa toda em developmentHC/conectaBemFront#209 (comentário da Poly de 19/05).

Como ela está pedindo uma definição de paginação e uma forma de exibir só um subset destacado, este PR adiciona os dois mecanismos.

## Mudanças

- `SPECIALTIES` ganha flag `featured: boolean`. Curados iniciais: `acupuntura`, `aromaterapia`, `meditacao`, `reiki`, `yoga` (5 de 20 — fácil ajustar via diff)
- `getSpecialties` aceita `?page=N` (limite fixo 10) e `?featured=true` (combináveis)
- Resposta vira `{ specialties, page, pageCount }`, mesmo padrão do `searchController`
- Swagger regenerado
- Testes Vitest cobrindo: shape paginado, page 2, clamp de page acima de pageCount, 400 em page inválida, `?featured=true` retornando só destacados, valor diferente de `"true"` sendo ignorado

## Quebra de contrato

Shape mudou de array para objeto paginado. O front **não** consome esse endpoint ao vivo ainda (continua nos mocks via `useGetSpecialty.ts`), então é seguro fundir antes da Poly subir o PR dela. Depois do merge, no `web` é só `npm run generate` pra atualizar os tipos Kubb.

## Validação local

Subi mongo via `docker-compose.dev.yaml`, rodei o servidor e baterei o endpoint:

| Caso | Resultado |
|---|---|
| `GET /specialties` | `pageCount=2`, 10 itens, cada um com `featured` |
| `GET /specialties?page=2` | 10 últimos |
| `GET /specialties?featured=true` | 5 destacados, `pageCount=1` |
| `GET /specialties?page=2&featured=true` | clamp pra `page=1` |
| `GET /specialties?page=-1` | `400 Página inválida` |
| `GET /specialties?page=99` | clamp pra última página |

`npm run lint`, `npm test` (113 passed | 1 skipped) e `npm run swagger` todos verdes.

## Test plan

- [ ] `npm install`
- [ ] `docker compose -f docker-compose.dev.yaml up -d`
- [ ] `npm run dev`
- [ ] `curl http://localhost:3000/specialties` — confere shape `{ specialties, page, pageCount }`
- [ ] `curl "http://localhost:3000/specialties?featured=true"` — confere que só destacados voltam
- [ ] `curl "http://localhost:3000/specialties?page=2"` — confere segunda página
- [ ] `npm test`

Refs: developmentHC/conectaBemFront#71, developmentHC/conectaBemFront#209

🤖 Generated with [Claude Code](https://claude.com/claude-code)